### PR TITLE
Change `asm-comments` to `verbose-asm`

### DIFF
--- a/compiler/base/orchestrator/src/coordinator.rs
+++ b/compiler/base/orchestrator/src/coordinator.rs
@@ -484,7 +484,7 @@ impl CompileRequest {
                 // Enable extra assembly comments for nightly builds
                 if let Channel::Nightly = self.channel {
                     args.push("-Z");
-                    args.push("asm-comments");
+                    args.push("verbose-asm");
                 }
 
                 args.push("-C");


### PR DESCRIPTION
This option was recently renamed. See <https://github.com/rust-lang/rust/pull/126803#event-13384747335>.